### PR TITLE
Fixes & cleanup

### DIFF
--- a/src/elkhound/gramanl.cc
+++ b/src/elkhound/gramanl.cc
@@ -3293,27 +3293,6 @@ void GrammarAnalysis::computeParseTables(bool allowAmbig)
       // add this entry to the table
       tables->setActionEntry(state->id, termId, cellAction);
 
-      // based on the contents of 'reductions', decide whether this
-      // state is delayed or not; to be delayed, the state must be
-      // able to reduce by a production which:
-      //   - has an ambiguous nonterminal as the last symbol on its RHS
-      //   - is not reducing to the *same* nonterminal as the last symbol
-      //     (rationale: eagerly reduce "E -> E + E")
-      // UPDATE: removed last condition because it actually makes things
-      // worse..
-      bool delayed = false;
-      if (reductions.isNotEmpty()) {    // no reductions: eager (irrelevant, actually)
-        SFOREACH_PRODUCTION(reductions, prodIter) {
-          Production const &prod = *prodIter.data();
-          if (prod.rhsLength() >= 1) {                 // nonempty RHS?
-            Symbol const *lastSym = prod.right.lastC()->sym;
-            if (isAmbiguousNonterminal(lastSym)        // last RHS ambig?
-                /*&& lastSym != prod.left*/) {         // not same as LHS?
-              delayed = true;
-            }
-          }
-        }
-      }
     }
 
     // ---- fill in this row in the goto table ----

--- a/src/smbase/crc.cpp
+++ b/src/smbase/crc.cpp
@@ -42,7 +42,7 @@ static unsigned long crc_table[256];
 
 void gen_crc_table()
  /* generate the table of CRC remainders for all possible bytes */
- { register int i, j;  register unsigned long crc_accum;
+ { int i, j;  unsigned long crc_accum;
    for ( i = 0;  i < 256;  i++ )
        { crc_accum = ( (unsigned long) i << 24 );
          for ( j = 0;  j < 8;  j++ )
@@ -58,7 +58,7 @@ void gen_crc_table()
 unsigned long update_crc(unsigned long crc_accum, char const *data_blk_ptr,
                                                     int data_blk_size)
  /* update the CRC on the data block one byte at a time */
- { register int i, j;
+ { int i, j;
    for ( j = 0;  j < data_blk_size;  j++ )
        { i = ( (int) ( crc_accum >> 24) ^ *data_blk_ptr++ ) & 0xff;
          crc_accum = ( crc_accum << 8 ) ^ crc_table[i]; }

--- a/src/smbase/exc.h
+++ b/src/smbase/exc.h
@@ -50,7 +50,7 @@ bool unwinding_other(xBase const &x);
 #define CAUTIOUS_RELAY           \
   catch (xBase &x) {             \
     if (!unwinding_other(x)) {   \
-      throw;   /* re-throw */    \
+      std::terminate();   /* terminate */ \
     }                            \
   }
 

--- a/src/smbase/sm_config.pm
+++ b/src/smbase/sm_config.pm
@@ -13,7 +13,11 @@ $| = 1;
 sub get_sm_config_version {
   $main::CC = getEnvOrDefault("CC", "gcc");
   $main::CXX = getEnvOrDefault("CXX", "g++");
-  @main::CCFLAGS = ("-g", "-Wall", "-Wno-deprecated", "-D__UNIX__");
+  @main::CCFLAGS = ("-g", "-Wall", "-D__UNIX__", "-Wno-class-memaccess", "-Wno-nonnull-compare", "-fno-strict-aliasing");
+  # if we don't add this, perl will warn us:
+  # Possible unintended interpolation of @main::CFLAGS in string at sm_config.pm
+  #
+  @main::CFLAGS = "";
   $main::debug = 0;
   $main::target = 0;
   $main::no_dash_g = 0;
@@ -317,12 +321,7 @@ sub test_CXX_compiler {
   print("Testing C++ compiler ...\n");
   my $cmd = "$main::CXX -o $testcout @main::CCFLAGS $main::SMBASE/testcout.cc";
   if (system($cmd)) {
-    # maybe problem is -Wno-deprecated?
-    printf("Trying without -Wno-deprecated ...\n");
-    @main::CCFLAGS = grep { $_ ne "-Wno-deprecated" } @main::CCFLAGS;
-    $cmd = "$main::CXX -o $testcout @main::CCFLAGS $main::SMBASE/testcout.cc";
-    if (system($cmd)) {
-      print(<<"EOF");
+    print(<<"EOF");
 
 I was unable to compile a really simple C++ program.  I tried:
   cd $wd
@@ -334,7 +333,6 @@ Until this is fixed, smbase (and any software that depends on it) will
 certainly not compile either.
 EOF
       exit(2);
-    }
   }
 
   if (!$target) {
@@ -369,9 +367,6 @@ EOF
     print("because we are in cross mode, I will not try running '$testcout'\n",
           "but it might be a good idea to try that yourself\n");
   }
-
-  # make a variant, CFLAGS, that doesn't include -Wno-deprecated
-  @main::CFLAGS = grep { $_ ne "-Wno-deprecated" } @main::CCFLAGS;
 }
 
 

--- a/src/smbase/strdict.h
+++ b/src/smbase/strdict.h
@@ -58,8 +58,8 @@ public:     // types
     IterC& operator= (IterC const &obj) { Iter::operator=(obj); return *this; }
 
     // some operations can be made available unchanged
-    Iter::isDone;
-    Iter::next;
+    using Iter::isDone;
+    using Iter::next;
 
     // others must be const-ified
     string const &key() const { return Iter::key(); }


### PR DESCRIPTION
These changes include
* Removal of -Wno-deprecated
* Removal of 'register' keyword
* Cleanup of unrequired code
* Removal of unrequired warnings(using -Wno)

This makes all warnings go away on:
```
» ~ gcc --version
gcc (GCC) 8.2.1 20181127
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
```
» ~ g++ --version
g++ (GCC) 8.2.1 20181127
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

note: this is untested on Windows with mingw

note2: tests failed before this patch too(on my linux machine), when running `make check`