### PR TITLE
Add -fno-strict-aliasing to compiler flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@ cmake_minimum_required(VERSION 3.0)
 # Global C flags
 set(CMAKE_C_FLAGS "-g -Wall -D__UNIX__ -fno-strict-aliasing")
 # Global C++ flags
-set(CMAKE_CXX_FLAGS "-g -Wall -Wno-class-memaccess")
+set(CMAKE_CXX_FLAGS "-g -Wall -Wno-class-memaccess -fno-strict-aliasing")
 
 # Use debugging optimisation for Debug builds
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Og")


### PR DESCRIPTION
This add `-fno-strict-aliasing` to the C++ compiler flags aswell, removes the warnings when compiling with `-DCMAKE_BUILD_TYPE=Release`