### PR TITLE
Replace deprecated '%pure-parser' with '%define api.pure'

### DIFF
--- a/src/ast/agrampar.y
+++ b/src/ast/agrampar.y
@@ -23,7 +23,7 @@
 
 /* ================== bison declarations =================== */
 // don't use globals
-%pure-parser
+%define api.pure
 %parse-param {void* parseParam}
 %lex-param {void* parseParam}
 

--- a/src/elkhound/grampar.y
+++ b/src/elkhound/grampar.y
@@ -59,7 +59,7 @@ AssocKind whichKind(LocString * /*owner*/ kind);
 
 /* ================== bison declarations =================== */
 // don't use globals
-%pure-parser
+%define api.pure
 %parse-param {void* parseParam}
 %lex-param {void* parseParam}
 


### PR DESCRIPTION
This commit removes the following warnings:
```
/home/tim/dev/elkhound/src/ast/agrampar.y:26.1-12: warning: deprecated directive: ‘%pure-parser’, use ‘%define api.pure’ [-Wdeprecated]
   26 | %pure-parser
      | ^~~~~~~~~~~~
      | %define api.pure
/home/tim/dev/elkhound/src/elkhound/grampar.y:62.1-12: warning: deprecated directive: ‘%pure-parser’, use ‘%define api.pure’ [-Wdeprecated]
   62 | %pure-parser
      | ^~~~~~~~~~~~
      | %define api.pure
```