### PR TITLE
Add defines needed by FLEX not to clobber numeric size macros on MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,6 +39,9 @@ else()
 
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS} /DNDEBUG")
     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} /DNDEBUG")
+
+    # FLEX code and output needs that not to clobber limit macros
+    add_compile_definitions(__STDC_VERSION__=199901L)
 endif()
 
 # Global include directories


### PR DESCRIPTION
MSVC does not claim to be a C99 compiler, thus FLEX boilerplate tries to redefine numeric size/limit macros. Added a define to fix that.