### PR TITLE
Fix un-escaped backslashes in emitted file name literals.

### DIFF
--- a/src/elkhound/emitcode.cc
+++ b/src/elkhound/emitcode.cc
@@ -94,7 +94,17 @@ string lineDirective(SourceLoc loc)
   int line, col;
   SourceLocManager::instance()->decodeLineCol(loc, fname, line, col);
 
-  return stringc << hashLine() << line << " \"" << fname << "\"\n";
+  std::string cfname;
+  for (const char* p = fname; *p; p++)
+  {
+    char c = *p;
+    if (c == '\\')
+      cfname.append("\\\\");
+    else
+      cfname.push_back(c);
+  }
+
+  return stringc << hashLine() << line << " \"" << cfname.c_str() << "\"\n";
 }
 
 stringBuilder &restoreLine(stringBuilder &sb)


### PR DESCRIPTION
On MSVC, generated files would have lines with invalid escapes:

    #line 120 "C:\foo\bar\baz"

This caused the debugger to be unable to find generated source files when debugging. The files it would try looking for had concatenated names like `elkhoundsrcastagramlex.cc` because the backslashes got ignored.

This change makes sure that all file names emitted into #line directives have the backlashes properly escaped.